### PR TITLE
Dynamic trajectory generator modify a set of waypoints

### DIFF
--- a/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
+++ b/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
@@ -151,7 +151,12 @@ class DynamicTrajectory {
   // principal functions
   void setWaypoints(const DynamicWaypoint::Vector &waypoints);
   void appendWaypoint(const DynamicWaypoint &waypoint);
-  void modifyWaypoint(const std::string &name, const Eigen::Vector3d &position);
+  void modifyWaypoint(
+    const std::string & name, const Eigen::Vector3d & position,
+    bool generate_new_traj = true);
+  void modifyWaypoints(
+    const std::vector<std::pair<std::string,
+    Eigen::Vector3d>> & waypoints_to_modified);
   bool evaluateTrajectory(const float &t, dynamic_traj_generator::References &refs,
                           bool only_positions = false, bool for_plotting = false);
   void generateTrajectory(const DynamicWaypoint::DynamicWaypoint::Deque &waypoints, bool force);

--- a/src/dynamic_trajectory.cpp
+++ b/src/dynamic_trajectory.cpp
@@ -105,7 +105,6 @@ namespace dynamic_traj_generator
     const std::vector<std::pair<std::string,
     Eigen::Vector3d>> & waypoints_to_modified)
   {
-    const std::lock_guard<std::mutex> lock(todo_mutex);
     // check if the waypoint is already in the waypoints to be modified list
     for (const auto & waypoint : waypoints_to_modified) {
       modifyWaypoint(waypoint.first, waypoint.second, false);


### PR DESCRIPTION
A new method named modifyWaypoints has been added to modify a set of waypoints. This method internally calls modifyWaypoint to modify each waypoint individually but allows the user to perform the modification with a single call.