### PR TITLE
Required change to build AS2 on Jazzy

### DIFF
--- a/subpackages/mav_trajectory_generation/CMakeLists.txt
+++ b/subpackages/mav_trajectory_generation/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-add_dependencies(${PROJECT_NAME} glog::glog nlopt yaml-cpp )
+add_dependencies(${PROJECT_NAME} glog::glog nlopt yaml-cpp::yaml-cpp )
 target_link_libraries(${PROJECT_NAME}
   glog::glog
   nlopt


### PR DESCRIPTION
This change is required to build [as2_behaviors_trajectory_generation](https://github.com/dvdmc/aerostack2/tree/jazzy/as2_behaviors/as2_behaviors_trajectory_generation) on ROS 2 Jazzy (see [aerostack2#784](https://github.com/aerostack2/aerostack2/pull/784)). 
Would it break anything on Humble? Otherwise, could this be merged into a Jazzy branch to pull from?