### PR TITLE
Remove yaml-cpp dependency from CMakeLists

### DIFF
--- a/subpackages/mav_trajectory_generation/CMakeLists.txt
+++ b/subpackages/mav_trajectory_generation/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-add_dependencies(${PROJECT_NAME} glog::glog nlopt yaml-cpp )
+add_dependencies(${PROJECT_NAME} glog::glog nlopt )
 target_link_libraries(${PROJECT_NAME}
   glog::glog
   nlopt


### PR DESCRIPTION
Working both for humble and jazzy ROS 2 distribution. Please @miferco97 take a look.