### PR TITLE
Configurable logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,17 @@ add_subdirectory(subpackages/mav_trajectory_generation)
 # uncomment the following section in order to fill in
 # further dependencies manually.
 # find_package(<dependency> REQUIRED)
-set(SOURCE_CPP_FILES 
+set(SOURCE_CPP_FILES
   src/dynamic_trajectory.cpp
   src/dynamic_waypoint.cpp
+  src/utils/logging_utils.cpp
 )
+
+# Logging toggle: define __SCREEN_OUTPUT__ at compile time. When OFF, the
+# DYNAMIC_LOG(...) macro expands to a no-op and no message is emitted. The user
+# can override the default with: cmake -DDYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING=OFF
+option(DYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING
+  "Enable on-screen logging from DYNAMIC_LOG (defines __SCREEN_OUTPUT__)" ON)
 
 include_directories(
   include
@@ -38,6 +45,9 @@ include_directories(
 add_library(${PROJECT_NAME} ${SOURCE_CPP_FILES})
 target_link_libraries(${PROJECT_NAME} mav_trajectory_generation nlopt )
 target_include_directories(${PROJECT_NAME} PUBLIC include include/${PROJECT_NAME} ${EIGEN3_INCLUDE_DIRS} )
+if(DYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC __SCREEN_OUTPUT__)
+endif()
 
 #check if tests are enabled
 if (${PROJECT_NAME}_PROFILING_ENABLED)

--- a/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
+++ b/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
@@ -11,8 +11,6 @@
 #include <string>
 #include <vector>
 
-#define __SCREEN_OUTPUT__
-
 #include "dynamic_waypoint.hpp"
 #include "mav_trajectory_generation/polynomial_optimization_linear.h"
 #include "mav_trajectory_generation/polynomial_optimization_nonlinear.h"

--- a/include/dynamic_trajectory_generator/utils/logging_utils.hpp
+++ b/include/dynamic_trajectory_generator/utils/logging_utils.hpp
@@ -2,7 +2,10 @@
 #define __LOGGING_UTILS_HPP__
 
 #include <chrono>
+#include <functional>
 #include <iostream>
+#include <sstream>
+#include <string>
 
 #define COUNT_TIME(_function_)                                                                                                                                     \
   {                                                                                                                                                                \
@@ -12,47 +15,50 @@
     std::cout << "[" << #_function_ << " ] takes :  " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() / 1000.0f << "s" << std::endl; \
   }
 
+namespace dynamic_traj_generator {
+
+using LogSink = std::function<void(const std::string &)>;
+
+// Enable or disable runtime logging. Default: ON (preserves prior behavior).
+// Has no effect when the library was compiled with
+// -DDYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING=OFF, because in that case the
+// DYNAMIC_LOG(...) macro is compiled out entirely and never consults the flag.
+void setLoggingEnabled(bool enabled);
+bool isLoggingEnabled();
+
+// Install a custom sink for the formatted log messages. Pass nullptr to
+// restore the default sink (writes to std::cout with a trailing newline).
+//
+// Typical use to route messages to the rclcpp logger of the owning ROS 2 node:
+//   dynamic_traj_generator::setLogSink(
+//     [node](const std::string & msg) {
+//       RCLCPP_INFO(node->get_logger(), "%s", msg.c_str());
+//     });
+//
+// Thread-safe: the sink may be reassigned at any time. The library serializes
+// access to the sink with an internal mutex.
+void setLogSink(LogSink sink);
+
+namespace logging_internal {
+// Implementation hook used by the DYNAMIC_LOG macro. Defined in
+// src/utils/logging_utils.cpp so that the underlying state is unique across
+// translation units and shared libraries.
+void emit(const std::string & message);
+}  // namespace logging_internal
+
+}  // namespace dynamic_traj_generator
+
 #ifndef __SCREEN_OUTPUT__
 #define DYNAMIC_LOG(...) ;
 #else
-#ifndef RCLCPP__LOGGER_HPP_
+#define DYNAMIC_LOG(x)                                                       \
+  do {                                                                       \
+    if (::dynamic_traj_generator::isLoggingEnabled()) {                      \
+      std::ostringstream _dtg_oss;                                           \
+      _dtg_oss << '[' << #x << "]: " << (x);                                 \
+      ::dynamic_traj_generator::logging_internal::emit(_dtg_oss.str());      \
+    }                                                                        \
+  } while (0)
+#endif  // __SCREEN_OUTPUT__
 
-template <typename T>
-static void PRINT_STRINGS(const char *name, T t)
-{
-  std::cout << '[' << name << "]: " << t << std::endl;
-}
-static void PRINT_STRINGS(const char *name, std::string s)
-{
-  std::cout << s << std::endl;
-}
-static void PRINT_STRINGS(const char *name, const char *s)
-{
-  std::cout << s << std::endl;
-}
-
-#define DYNAMIC_LOG(x) PRINT_STRINGS(#x, x)
-
-#else // RCLCPP__LOGGER_HPP_
-
-template <typename T>
-static void PRINT_ROS2_STRINGS(const char *name, T t)
-{
-  RCLCPP_INFO(rclcpp::get_logger("dynamic_traj_generator"), "[%s]: %s", name, t);
-}
-static void PRINT_ROS2_STRINGS(const char *name, std::string s)
-{
-  RCLCPP_INFO(rclcpp::get_logger("dynamic_traj_generator"), "%s", s.c_str());
-}
-static void PRINT_ROS2_STRINGS(const char *name, const char *s)
-{
-  RCLCPP_INFO(rclcpp::get_logger("dynamic_traj_generator"), "%s", s);
-}
-
-#define DYNAMIC_LOG(x) PRINT_ROS2_STRINGS(#x, x)
-
-#endif // RCLCPP__LOGGER_HPP_
-
-#endif // __SCREEN_OUTPUT__
-
-#endif // __LOGGING_UTILS_HPP__
+#endif  // __LOGGING_UTILS_HPP__

--- a/pybind/src/module.cpp
+++ b/pybind/src/module.cpp
@@ -55,6 +55,7 @@ PYBIND11_MODULE(_dynamic_trajectory_generator_cpp, m)
       py::arg("initial_yaw"),
       py::arg("waypoints"),
       py::arg("max_velocity"),
+      py::call_guard<py::gil_scoped_release>(),
       "Generate a polynomial trajectory from the current vehicle position through the given "
       "waypoints at the given maximum velocity. Blocks until the optimizer returns.")
     .def(
@@ -80,4 +81,31 @@ PYBIND11_MODULE(_dynamic_trajectory_generator_cpp, m)
       "get_was_trajectory_regenerated",
       &dynamic_traj_generator::DynamicTrajectoryBind::getWasTrajectoryRegenerated,
       "Return whether the trajectory has been regenerated since the last query.");
+
+  m.def(
+    "set_logging_enabled",
+    &dynamic_traj_generator::setLoggingEnabled,
+    py::arg("enabled"),
+    "Enable or disable runtime logging from the generator. Default: enabled. "
+    "Has no effect if the library was compiled with "
+    "-DDYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING=OFF.");
+
+  m.def(
+    "set_log_sink",
+    [](py::object callback) {
+      if (callback.is_none()) {
+        dynamic_traj_generator::setLogSink(nullptr);
+        return;
+      }
+      auto cb = callback.cast<py::function>();
+      dynamic_traj_generator::setLogSink(
+        [cb](const std::string & msg) {
+          py::gil_scoped_acquire gil;
+          cb(msg);
+        });
+    },
+    py::arg("callback"),
+    "Install a Python callable as the log sink. The callable receives the "
+    "formatted message as a single string argument. Pass None to restore the "
+    "default sink (stdout).");
 }

--- a/src/utils/logging_utils.cpp
+++ b/src/utils/logging_utils.cpp
@@ -1,0 +1,64 @@
+#include "dynamic_trajectory_generator/utils/logging_utils.hpp"
+
+#include <atomic>
+#include <iostream>
+#include <mutex>
+#include <utility>
+
+namespace dynamic_traj_generator {
+
+namespace {
+
+// Default ON to preserve the prior behavior of the library (logs visible
+// without any explicit configuration when compiled with __SCREEN_OUTPUT__).
+std::atomic<bool> & enabledFlag()
+{
+  static std::atomic<bool> flag{true};
+  return flag;
+}
+
+std::mutex & sinkMutex()
+{
+  static std::mutex m;
+  return m;
+}
+
+LogSink & sinkRef()
+{
+  static LogSink sink;
+  return sink;
+}
+
+}  // namespace
+
+void setLoggingEnabled(bool enabled)
+{
+  enabledFlag().store(enabled, std::memory_order_relaxed);
+}
+
+bool isLoggingEnabled()
+{
+  return enabledFlag().load(std::memory_order_relaxed);
+}
+
+void setLogSink(LogSink sink)
+{
+  std::lock_guard<std::mutex> lock(sinkMutex());
+  sinkRef() = std::move(sink);
+}
+
+namespace logging_internal {
+
+void emit(const std::string & message)
+{
+  std::lock_guard<std::mutex> lock(sinkMutex());
+  if (sinkRef()) {
+    sinkRef()(message);
+  } else {
+    std::cout << message << std::endl;
+  }
+}
+
+}  // namespace logging_internal
+
+}  // namespace dynamic_traj_generator


### PR DESCRIPTION
## Summary

- Replace the hardcoded `#define __SCREEN_OUTPUT__` with a CMake option (`DYNAMIC_TRAJECTORY_GENERATOR_ENABLE_LOGGING`, ON by default).
- Add a small runtime API (`setLoggingEnabled`, `setLogSink`) so consumers can silence the generator or route its messages without recompiling or editing sources.
- Expose the same controls through the Python bindings.

## Motivation
`DYNAMIC_LOG(...)` was permanently bound to `std::cout` because
`dynamic_trajectory.hpp` hardcoded `#define __SCREEN_OUTPUT__`. Downstream
consumers — both C++ packages and the Python binding — had no way to silence
the generator or route its output (for example, to an `rclcpp` logger) without
patching sources. The pre-existing RCLCPP branch in `logging_utils.hpp` was
effectively unreachable from a downstream user, since the macro is preprocessed
when this library is compiled, not when its header is included downstream.