### PR TITLE
Add low-speed heuristic factors for segment time estimation

### DIFF
--- a/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
+++ b/include/dynamic_trajectory_generator/dynamic_trajectory.hpp
@@ -90,6 +90,9 @@ class DynamicTrajectory {
   const int dimension_ = 3;
   std::atomic_bool from_scratch_ = true;
   const double a_max_ = MAV_MAX_ACCEL;
+  // Low-speed segment factors
+  double ls_velocity_factor_ = 1.0;
+  double ls_acceleration_factor_ = 1.0;
   Eigen::Vector3d vehicle_position_;
 
   mutable std::mutex traj_mutex_;
@@ -177,6 +180,12 @@ class DynamicTrajectory {
 
   // getters
   void setSpeed(double speed);
+  // Apply ls_velocity_factor * v_max and ls_acceleration_factor * a_max
+  // on segments whose next waypoint's name contains the substring "ls".
+  // Defaults are 1.0 (no-op). Setters so a consumer can configure them
+  // on each generator instance after construction.
+  inline void setLowSpeedVelocityFactor(double factor) { ls_velocity_factor_ = factor; }
+  inline void setLowSpeedAccelerationFactor(double factor) { ls_acceleration_factor_ = factor; }
   double getMaxTime();
   double getMinTime();
   DynamicWaypoint::Deque getDynamicWaypoints();

--- a/src/dynamic_trajectory.cpp
+++ b/src/dynamic_trajectory.cpp
@@ -302,17 +302,36 @@ namespace dynamic_traj_generator
     float max_speed = parameters_.speed;
     parameters_mutex_.unlock();
 
-    /* auto vertices = extractVerticesFromWaypoints(waypoints); */
     auto vertices = extractVerticesFromWaypoints(next_trajectory_waypoint_);
-    if (vertices.size() < 2)
-    {
-      throw std::runtime_error("Not enough waypoints");
+
+    // estimateSegmentTimes estimates each segment independently (see
+    // estimateSegmentTimesNfabian), so the per-segment scaling below produces
+    // the exact same times as the global call for non-low-speed segments.
+    std::vector<double> segment_times;
+    if ((ls_velocity_factor_ != 1.0) || (ls_acceleration_factor_ != 1.0)) {
+      // Low-speed modifiers active: estimate each segment once with its own
+      // limits. A segment whose target waypoint name contains "ls" uses the
+      // reduced velocity/acceleration so the drone slows down there; the rest
+      // use the nominal limits. No segment is estimated twice.
+      segment_times.reserve(vertices.size() > 0 ? vertices.size() - 1 : 0);
+      for (size_t i = 0; i + 1 < vertices.size(); ++i) {
+        const bool low = i + 1 < next_trajectory_waypoint_.size() &&
+                         next_trajectory_waypoint_[i + 1].getName().find("ls") != std::string::npos;
+        const double v = low ? max_speed * ls_velocity_factor_ : max_speed;
+        const double a = low ? this->a_max_ * ls_acceleration_factor_ : this->a_max_;
+        const mav_trajectory_generation::Vertex::Vector segment = {vertices[i], vertices[i + 1]};
+        segment_times.push_back(
+            mav_trajectory_generation::estimateSegmentTimes(segment, v, a).front());
+      }
+    } else {
+      // No low-speed factors: single global estimate
+      segment_times =
+          mav_trajectory_generation::estimateSegmentTimes(vertices, max_speed, this->a_max_);
     }
+
     const int N = 10;
     std::shared_ptr<mav_trajectory_generation::Trajectory> trajectory =
         std::make_shared<mav_trajectory_generation::Trajectory>();
-    auto segment_times =
-        mav_trajectory_generation::estimateSegmentTimes(vertices, max_speed, this->a_max_);
     // Optimizer
     if (lineal_optimization)
     {


### PR DESCRIPTION
Segments whose next waypoint name contains the "ls" token are estimated with reduced velocity/acceleration limits (ls_velocity_factor / ls_acceleration_factor), so the trajectory slows down there. The upstream estimateSegmentTimes is reused per-segment; with both factors at 1.0 the behaviour is identical to before (single global estimate).